### PR TITLE
Bugfix

### DIFF
--- a/Public/Objects/Compare-ObjectProperties.ps1
+++ b/Public/Objects/Compare-ObjectProperties.ps1
@@ -8,7 +8,7 @@ Function Compare-ObjectProperties {
                   $($ReferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name),
                   $($DifferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name)
                   )
-    $objprops = $objprops | Sort-Object | Select-Object -Unique
+    $objprops = $objprops | Sort-Object -Unique
     $diffs = foreach ($objprop in $objprops) {
         $diff = Compare-Object $ReferenceObject $DifferenceObject -Property $objprop -CaseSensitive:$CaseSensitive
         if ($diff) {

--- a/Public/Objects/Compare-ObjectProperties.ps1
+++ b/Public/Objects/Compare-ObjectProperties.ps1
@@ -4,16 +4,18 @@ Function Compare-ObjectProperties {
         [PSObject]$DifferenceObject,
         [switch]$CaseSensitive = $false
     )
-    $objprops = $ReferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name
-    $objprops += $DifferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name
+    $objprops = @(
+                  $($ReferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name),
+                  $($DifferenceObject | Get-Member -MemberType Property, NoteProperty | ForEach-Object Name)
+                  )
     $objprops = $objprops | Sort-Object | Select-Object -Unique
     $diffs = foreach ($objprop in $objprops) {
-        $diff = Compare-Object $ReferenceObject $DifferenceObject -Property $objprop -CaseSensitive $CaseSensitive
+        $diff = Compare-Object $ReferenceObject $DifferenceObject -Property $objprop -CaseSensitive:$CaseSensitive
         if ($diff) {
             $diffprops = [PsCustomObject] @{
                 PropertyName = $objprop
-                RefValue     = ($diff | Where-Object {$_.SideIndicator -eq '<='} | Foreach-Obect $($objprop))
-                DiffValue    = ($diff | Where-Object {$_.SideIndicator -eq '=>'} | Foreach-Obect $($objprop))
+                RefValue     = ($diff | Where-Object {$_.SideIndicator -eq '<='} | ForEach-Object $($objprop))
+                DiffValue    = ($diff | Where-Object {$_.SideIndicator -eq '=>'} | ForEach-Object $($objprop))
             }
             $diffprops
             #New-Object PSObject -Property $diffprops


### PR DESCRIPTION
- Array for Reference and Difference Object
- Fixed Typo
- Fixed Syntaxerror with $true/$False for parameter CaseSensitiv
   Correct: -CaseSensitive:$true 
   Wrong: -CaseSensitive $true